### PR TITLE
Gerilya/feature/shrink/migrate aliases

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1931,18 +1931,19 @@ class Shrink(object):
             report_failure(e)
 
     def get_migrate_aliases_body(self,source,target):
-        body = None
         actions = []
         aliases = self.client.indices.get_alias()
-        if source in aliases:
-            for alias in aliases[source]['aliases']:
-                # actions.append({ 'add' :    { 'index' : new_index, 'alias': alias } })
-                add_dict = { 'add' : { 'index' : target, 'alias': alias } }
-                add_dict['add'].update(aliases[source]['aliases'][alias])
-                actions.append(add_dict)
-                actions.append({ 'remove' : { 'index' : source, 'alias': alias } })
-            body = { 'actions' : actions }
-        return body
+        if source not in aliases:
+            return None
+        for alias in aliases[source]['aliases']:
+            # actions.append({ 'add' :    { 'index' : new_index, 'alias': alias } })
+            add_dict = { 'add' : { 'index' : target, 'alias': alias } }
+            add_dict['add'].update(aliases[source]['aliases'][alias])
+            actions.append(add_dict)
+            actions.append({ 'remove' : { 'index' : source, 'alias': alias } })
+        if not actions:
+            return None
+        return { 'actions' : actions }
 
     def __log_action(self, error_msg, dry_run=False):
         if not dry_run:

--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1930,6 +1930,26 @@ class Shrink(object):
         except Exception as e:
             report_failure(e)
 
+    def migrate_aliases(self,source,target):
+        actions = []
+        aliases = self.client.indices.get_alias()
+        if source in aliases:
+            for alias in aliases[old_index]['aliases']:
+                # actions.append({ 'add' :    { 'index' : new_index, 'alias': alias } })
+                add_dict = { 'add' : { 'index' : target, 'alias': alias } }
+                add_dict['add'].update(aliases[source]['aliases'][alias])
+                actions.append(add_dict)
+                actions.append({ 'remove' : { 'index' : source, 'alias': alias } })
+            body = { 'actions' : actions }
+        self.loggit.info('Migrating aliases from {0} index to {1} index...'.format(source,target))
+        self.loggit.info('Alias actions: {0}'.format(body))
+        if dry_run:
+            return
+        try:
+            self.client.indices.update_aliases(body=body)
+        except Exception as e:
+            report_failure(e)
+
     def __log_action(self, error_msg, dry_run=False):
         if not dry_run:
             raise ActionError(error_msg)
@@ -2042,6 +2062,7 @@ class Shrink(object):
                     self.loggit.info('DRY-RUN: Shrinking index "{0}" to "{1}" with settings: {2}, wait_for_active_shards={3}'.format(idx, target, self.body, self.wait_for_active_shards))
                     if self.post_allocation:
                         self.loggit.info('DRY-RUN: Applying post-shrink allocation rule "{0}" to index "{1}"'.format('index.routing.allocation.{0}.{1}:{2}'.format(self.post_allocation['allocation_type'], self.post_allocation['key'], self.post_allocation['value']), target))
+
                     if self.delete_after:
                         self.loggit.info('DRY-RUN: Deleting source index "{0}"'.format(idx))
         except Exception as e:
@@ -2083,6 +2104,8 @@ class Shrink(object):
                     if self.post_allocation:
                         self.loggit.info('Applying post-shrink allocation rule "{0}" to index "{1}"'.format('index.routing.allocation.{0}.{1}:{2}'.format(self.post_allocation['allocation_type'], self.post_allocation['key'], self.post_allocation['value']), target))
                         self.route_index(target, self.post_allocation['allocation_type'], self.post_allocation['key'], self.post_allocation['value'])
+                    ## Migrate aliases to the target index
+                    migrate_aliases(idx,target)
                     ## Delete, if flagged
                     if self.delete_after:
                         self.loggit.info('Deleting source index "{0}"'.format(idx))

--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1931,6 +1931,7 @@ class Shrink(object):
             report_failure(e)
 
     def get_migrate_aliases_body(self,source,target):
+        body = None
         actions = []
         aliases = self.client.indices.get_alias()
         if source in aliases:
@@ -2105,7 +2106,8 @@ class Shrink(object):
                     migrate_aliases_body = self.get_migrate_aliases_body(idx,target)
                     self.loggit.info('Migrating aliases from {0} index to {1} index...'.format(idx,target))
                     self.loggit.info('Migrate alias actions: {0}'.format(migrate_aliases_body))
-                    self.client.indices.update_aliases(body=migrate_aliases_body)
+                    if migrate_aliases_body is not None:
+                        self.client.indices.update_aliases(body=migrate_aliases_body)
                     ## Delete, if flagged
                     if self.delete_after:
                         self.loggit.info('Deleting source index "{0}"'.format(idx))

--- a/curator/defaults/option_defaults.py
+++ b/curator/defaults/option_defaults.py
@@ -27,6 +27,9 @@ def delay():
             )
     }
 
+def migrate_aliases():
+    return { Optional('migrate_aliases', default=False): Any(bool, All(Any(str, unicode), Boolean())) }
+
 def delete_after():
     return { Optional('delete_after', default=True): Any(bool, All(Any(str, unicode), Boolean())) }
 

--- a/curator/validators/options.py
+++ b/curator/validators/options.py
@@ -115,6 +115,7 @@ def action_specific(action):
             option_defaults.number_of_replicas(),
             option_defaults.shrink_prefix(),
             option_defaults.shrink_suffix(),
+            option_defaults.migrate_aliases(),
             option_defaults.delete_after(),
             option_defaults.post_allocation(),
             option_defaults.wait_for_active_shards(action),

--- a/docs/asciidoc/actions.asciidoc
+++ b/docs/asciidoc/actions.asciidoc
@@ -1009,6 +1009,7 @@ options:
   number_of_replicas: 1
   shrink_prefix:
   shrink_suffix: '-shrink'
+  migrate_aliases: True
   delete_after: True
   post_allocation:
     allocation_type: include
@@ -1056,6 +1057,10 @@ are identified for shrinking by the filter block, and `DETERMINISTIC` is specifi
 the node selection process will be repeated for each successive index, preventing
 all of the space being consumed on a single node.
 
+Upon successful shrink, you might want to migrate the aliases from the source index to the target index.
+This can be especially useful if you want to delete the source index.
+In order to achive that, set The <<option_migrate_aliases,migrate_aliases>> option to True.
+
 By default, Curator will delete the source index after a successful shrink. This
 can be disabled by setting <<option_delete_after,delete_after>> to `False`.  If the source index,
 is not deleted after a successful shrink, Curator will remove the read-only setting and the
@@ -1082,6 +1087,7 @@ as needed.
 
 * <<option_continue,continue_if_exception>>
 * <<option_ignore_empty,ignore_empty_list>>
+* <<option_migrate_aliases,migrate_aliases>>
 * <<option_delete_after,delete_after>>
 * <<option_disable,disable_action>>
 * <<option_extra_settings,extra_settings>>

--- a/docs/asciidoc/examples.asciidoc
+++ b/docs/asciidoc/examples.asciidoc
@@ -720,6 +720,7 @@ actions:
       number_of_replicas: 1
       shrink_prefix:
       shrink_suffix: '-shrink'
+      migrate_aliases: True
       delete_after: True
       post_allocation:
         allocation_type: include

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -169,6 +169,27 @@ forceMerging indices, to allow the cluster to quiesce.
 
 There is no default value.
 
+[[option_migrate_aliases]]
+== migrate_aliases
+
+NOTE: This setting is only used by the <<shrink,shrink>> action.
+
+[source,yaml]
+-------------
+action: shrink
+description: >-
+  Shrink selected indices on the node with the most available space.
+  Migrate all aliases associated with the source index to the target index.
+options:
+  shrink_node: DETERMINISTIC
+  migrate_aliases: True
+filters:
+  - filtertype: ...
+-------------
+
+The default value of this setting is `False`.  After an index has been successfully
+shrunk, the aliases of the source index will be migrated to the target index if the value of this settings is True.
+
 
 [[option_delete_after]]
 == delete_after


### PR DESCRIPTION
This branch further extends shrink action ( https://github.com/elastic/curator/pull/1034 ) by adding an option to 'migrate' all aliases of the source index to the target index in 1 atomic operation (see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html)
